### PR TITLE
make DISv7 EE Pdu update filter default behavior same as previous versio...

### DIFF
--- a/src/dis/EmissionPduHandler.cpp
+++ b/src/dis/EmissionPduHandler.cpp
@@ -591,7 +591,7 @@ bool EmissionPduHandler::isUpdateRequired(const LCreal curExecTime, bool* const 
    // otherwise, could be entirely removed.
    if (disIO->getVersion() >= NetIO::VERSION_7) {
       LCreal drTime = curExecTime - getEmPduExecTime();
-      if ( drTime < (disIO->getHbtPduEe() /10.0f) ) {
+      if ( drTime < (disIO->getHbtPduEe() /20.0f) ) {
          result = NO;
       }
    }


### PR DESCRIPTION
...n - no updates until .5s has elapsed.

(DISv7 code was using twice that)
