### PR TITLE
ThreadPeriodicTask graceful termination

### DIFF
--- a/include/openeaagles/basic/Thread.h
+++ b/include/openeaagles/basic/Thread.h
@@ -186,6 +186,12 @@ class ThreadPeriodicTask : public Thread {
 public:
    ThreadPeriodicTask(Component* const parent, const LCreal priority, const LCreal rate);
 
+   // Create/start the child thread
+   virtual bool create();
+
+   // Terminate the child thread
+   virtual bool terminate();
+
    LCreal getRate() const;                         // Update rate (must be greater than zero)
    unsigned int getTotalFrameCount() const;        // Total frame count
 
@@ -214,6 +220,7 @@ private:
    Statistic bfStats;   // Busted (overrun) frame statistics (windows only)
    unsigned int tcnt;   // total frame count
    bool vdtFlg;         // Variable delta time flag
+   bool shutdownThread;
 };
 
 //------------------------------------------------------------------------------

--- a/src/basic/windows/Thread.cxx
+++ b/src/basic/windows/Thread.cxx
@@ -207,6 +207,26 @@ bool Thread::terminate()
 //==============================================================================
 // class ThreadPeriodicTask
 //==============================================================================
+//-----------------------------------------------------------------------------
+// Create the thread
+//-----------------------------------------------------------------------------
+bool ThreadPeriodicTask::create()
+{
+   shutdownThread = false;
+   return BaseClass::create();
+}
+
+//-----------------------------------------------------------------------------
+// Treminate the thread
+//-----------------------------------------------------------------------------
+bool ThreadPeriodicTask::terminate()
+{
+   shutdownThread = true;
+   while (!isTerminated()){
+      Sleep(1);
+   }
+   return isTerminated();
+}
 
 //-----------------------------------------------------------------------------
 // Our main thread function
@@ -230,7 +250,7 @@ unsigned long ThreadPeriodicTask::mainThreadFunc()
       const double startTime = getComputerTime();;           // Computer's time of day (sec) run started
       double dt = 1.0/static_cast<double>(getRate());
 
-      while (!getParent()->isShutdown()) {
+      while (!getParent()->isShutdown() && !shutdownThread) {
 
          // ---
          // User defined tasks


### PR DESCRIPTION
I was trying to solve an issue where reset was causing a crash (mainly in Navigation::updateNavSteering()) but my fix was that I wanted to make a station that stops all of the threads before resetting and then calls BaseClass::reset() ect, and restarts the threads.  I was unable to do this because when i terminate the thread with the old code the thread would stop wherever it was so if it was in the middle of a lock it would remain locked forever.  
