### PR TITLE
Reworked Makefiles to allow for parallel builds via `make -j`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,11 @@
 
 # Libraries
-LIBS = src
+SUBDIRS = src
 
-all:
-	for subdir in $(LIBS); do \
-	  echo making $@ in $$subdir; \
-	  (cd $$subdir && $(MAKE)) || exit 1; \
-	done
+all: $(SUBDIRS)
 
-clean:
-	for subdir in $(LIBS); do \
-	    echo $@ in $$subdir; \
-	    (cd $$subdir && $(MAKE) $@) || exit 1; \
-	done
+clean: $(SUBDIRS)
+    
+$(SUBDIRS)::
+	$(MAKE) -C $@ $(MAKECMDGOALS)
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -49,12 +49,7 @@ PROJECTS += otw
 #
 # Rules
 #
-all:
-	@echo ${OE_ROOT}
-	for subdir in $(PROJECTS); do \
-	  echo making $@ in $$subdir; \
-	  (cd $$subdir && $(MAKE)) || exit 1; \
-	done
+all: $(PROJECTS)
 
 install: uninstall
 	-cp -r ../include/openeaagles /usr/local/include/openeaagles
@@ -64,10 +59,10 @@ uninstall:
 	-rm -rf /usr/local/include/openeaagles
 	-rm -rf /usr/local/lib/openeaagles
 
-clean:
+clean: $(PROJECTS)
 	-rm -f *.o
-	for subdir in $(PROJECTS); do \
-	    echo $@ in $$subdir; \
-	    (cd $$subdir && $(MAKE) $@) || exit 1; \
-	done
+
+$(PROJECTS)::
+	@echo making in $@
+	$(MAKE) -j 1 -C $@ $(MAKECMDGOALS)
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -20,36 +20,38 @@ include makedefs
 # simulation   : -
 # terrain      : -
 #
-PROJECTS = basic
-PROJECTS += basicGL instruments
-PROJECTS += dafif
-PROJECTS += ioDevice
-PROJECTS += linearSys 
-PROJECTS += simulation sensors terrain
-PROJECTS += dis
-PROJECTS += dynamics
-PROJECTS += maps
-PROJECTS += recorder
+SUBDIRS = basic
+SUBDIRS += basicGL 
+SUBDIRS += instruments
+SUBDIRS += dafif
+SUBDIRS += ioDevice
+SUBDIRS += linearSys 
+SUBDIRS += simulation sensors terrain
+SUBDIRS += dis
+SUBDIRS += dynamics
+SUBDIRS += maps
+SUBDIRS += recorder
 
 #
 # GUI interface libraries
 #
-PROJECTS += "gui/glut"
+SUBDIRS += "gui/glut"
 
 # Out-the-Window interface classes to talk to visual systems
 # - CIGI Class Library 3.x interface
 # - download and install cigicl
-PROJECTS += otw
+SUBDIRS += otw
 
 #
 # HLA interface library
 #
-#PROJECTS += "hla"
+#SUBDIRS += "hla"
 
 #
 # Rules
 #
-all: $(PROJECTS)
+
+all: $(SUBDIRS)
 
 install: uninstall
 	-cp -r ../include/openeaagles /usr/local/include/openeaagles
@@ -59,10 +61,8 @@ uninstall:
 	-rm -rf /usr/local/include/openeaagles
 	-rm -rf /usr/local/lib/openeaagles
 
-clean: $(PROJECTS)
+clean: $(SUBDIRS)
 	-rm -f *.o
 
-$(PROJECTS)::
-	@echo making in $@
-	$(MAKE) -j 1 -C $@ $(MAKECMDGOALS)
-
+$(SUBDIRS)::
+	$(MAKE) -C $@ $(MAKECMDGOALS)

--- a/src/basic/Makefile
+++ b/src/basic/Makefile
@@ -4,88 +4,79 @@ include ../makedefs
 LIB = $(OPENEAAGLES_LIB_DIR)/liboeBasic.a
 
 OBJS =  \
-	$(LIB)(support.o) \
-	$(LIB)(basicFF.o) \
-	$(LIB)(Boolean.o) \
-	$(LIB)(Cie.o) \
-	$(LIB)(Cmy.o) \
-	$(LIB)(Color.o) \
-	$(LIB)(Complex.o) \
-	$(LIB)(Component.o) \
-	$(LIB)(Decibel.o) \
-	$(LIB)(EarthModel.o) \
-	$(LIB)(Factory.o) \
-	$(LIB)(FileReader.o) \
-	$(LIB)(Float.o) \
-	$(LIB)(Function.o) \
-	$(LIB)(Functions.o) \
-	$(LIB)(Hls.o) \
-	$(LIB)(Hsva.o) \
-	$(LIB)(Hsv.o) \
-	$(LIB)(Identifier.o) \
-	$(LIB)(Integer.o) \
-	$(LIB)(IoAdapter.o) \
-	$(LIB)(IoData.o) \
-	$(LIB)(IoDevice.o) \
-	$(LIB)(IoHandler.o) \
-	$(LIB)(LatLon.o) \
-	$(LIB)(Lexical.o) \
-	$(LIB)(List.o) \
-	$(LIB)(Locus.o) \
-	$(LIB)(Logger.o) \
-	$(LIB)(Matrix.o) \
-	$(LIB)(Nav.o) \
-	$(LIB)(NavDR.o) \
-	$(LIB)(NetHandler.o) \
-	$(LIB)(Number.o) \
-	$(LIB)(Object.o) \
-	$(LIB)(Operators.o) \
-	$(LIB)(Pair.o) \
-	$(LIB)(PairStream.o) \
-	$(LIB)(Parser.o) \
-	$(LIB)(Rgba.o) \
-	$(LIB)(Rgb.o) \
-	$(LIB)(Rng.o) \
-	$(LIB)(SlotTable.o) \
-	$(LIB)(Stack.o) \
-	$(LIB)(Statistic.o) \
-	$(LIB)(StateMachine.o) \
-	$(LIB)(String.o) \
-	$(LIB)(Table.o) \
-	$(LIB)(Tables.o) \
-	$(LIB)(Terrain.o) \
-	$(LIB)(Thread.o) \
-	$(LIB)(ThreadPool.o) \
-	$(LIB)(Timers.o) \
-	$(LIB)(Transforms.o) \
-	$(LIB)(Vectors.o) \
-	$(LIB)(Yiq.o)
+	support.o \
+	basicFF.o \
+	Boolean.o \
+	Cie.o \
+	Cmy.o \
+	Color.o \
+	Complex.o \
+	Component.o \
+	Decibel.o \
+	EarthModel.o \
+	Factory.o \
+	FileReader.o \
+	Float.o \
+	Hls.o \
+	Hsva.o \
+	Hsv.o \
+	Identifier.o \
+	Integer.o \
+	IoAdapter.o \
+	IoData.o \
+	IoDevice.o \
+	IoHandler.o \
+	LatLon.o \
+	Lexical.o \
+	List.o \
+	Locus.o \
+	Logger.o \
+	Matrix.o \
+	Nav.o \
+	NavDR.o \
+	NetHandler.o \
+	Number.o \
+	Object.o \
+	Operators.o \
+	Pair.o \
+	PairStream.o \
+	Parser.o \
+	Rgba.o \
+	Rgb.o \
+	Rng.o \
+	SlotTable.o \
+	Stack.o \
+	Statistic.o \
+	StateMachine.o \
+	String.o \
+	Terrain.o \
+	Thread.o \
+	ThreadPool.o \
+	Timers.o \
+	Transforms.o \
+	Vectors.o \
+	Yiq.o
 
 SUBDIRS = distributions functors nethandlers osg ubf units util
 
-all: subdirs ${OBJS}
-
-subdirs:
+all:
+	$(MAKE) compile
+	$(MAKE) archive
+    
+compile: $(SUBDIRS) ${OBJS}
+    
+archive:
 	for subdir in $(SUBDIRS); do \
-	  echo making $@ in $$subdir; \
-	  (cd $$subdir && $(MAKE)) || exit 1; \
+		$(MAKE) -C $$subdir $(MAKECMDGOALS); \
 	done
+	ar rv $(LIB) ${OBJS}
 
-$(LIB)(Lexical.o): Lexical.cpp Parser.cpp Parser.hpp
+Lexical.o: Lexical.cpp Parser.cpp Parser.hpp
 
-#Parser.cpp:  Parser.y
-#	dos2unix Parser.y
-#	bison -t Parser.y -o Parser.cpp
-
-#Lexical.cpp: Lexical.l
-#	dos2unix Lexical.l
-#	flex -f -oLexical.cpp Lexical.l
-
-clean:
+clean: $(SUBDIRS)
 	-rm -f *.o
-	for subdir in $(SUBDIRS); do \
-	    echo making $@ in $$subdir; \
-	    (cd $$subdir && $(MAKE) $@) || exit 1; \
-	done
 	-rm -f $(LIB)
+    
+$(SUBDIRS)::
+	$(MAKE) -C $@ $(MAKECMDGOALS)
 

--- a/src/basic/distributions/Makefile
+++ b/src/basic/distributions/Makefile
@@ -4,12 +4,19 @@ include ../../makedefs
 LIB = $(OPENEAAGLES_LIB_DIR)/liboeBasic.a
 
 OBJS =  \
-	$(LIB)(Exponential.o) \
-	$(LIB)(Lognormal.o) \
-	$(LIB)(Pareto.o) \
-	$(LIB)(Uniform.o)
+	Exponential.o \
+	Lognormal.o \
+	Pareto.o \
+	Uniform.o
 
-all: ${OBJS}
+all:
+	$(MAKE) compile
+	$(MAKE) archive
+    
+compile: ${OBJS}
+    
+archive:
+	ar rv $(LIB) ${OBJS}
 
 clean:
 	-rm -f *.o

--- a/src/basic/functors/Makefile
+++ b/src/basic/functors/Makefile
@@ -4,12 +4,19 @@ include ../../makedefs
 LIB = $(OPENEAAGLES_LIB_DIR)/liboeBasic.a
 
 OBJS =  \
-	$(LIB)(Function.o) \
-	$(LIB)(Functions.o) \
-	$(LIB)(Table.o) \
-	$(LIB)(Tables.o)
+	Function.o \
+	Functions.o \
+	Table.o \
+	Tables.o
 
-all: ${OBJS}
+all:
+	$(MAKE) compile
+	$(MAKE) archive
+    
+compile: ${OBJS}
+    
+archive:
+	ar rv $(LIB) ${OBJS}
 
 clean:
 	-rm -f *.o

--- a/src/basic/nethandlers/Makefile
+++ b/src/basic/nethandlers/Makefile
@@ -4,16 +4,23 @@ include ../../makedefs
 LIB = $(OPENEAAGLES_LIB_DIR)/liboeBasic.a
 
 OBJS =  \
-	$(LIB)(PosixHandler.o) \
-	$(LIB)(TcpClient.o) \
-	$(LIB)(TcpHandler.o) \
-	$(LIB)(TcpServerMultiple.o) \
-	$(LIB)(TcpServerSingle.o) \
-	$(LIB)(UdpBroadcastHandler.o) \
-	$(LIB)(UdpMulticastHandler.o) \
-	$(LIB)(UdpUnicastHandler.o)
+	PosixHandler.o \
+	TcpClient.o \
+	TcpHandler.o \
+	TcpServerMultiple.o \
+	TcpServerSingle.o \
+	UdpBroadcastHandler.o \
+	UdpMulticastHandler.o \
+	UdpUnicastHandler.o
 
-all: ${OBJS}
+all:
+	$(MAKE) compile
+	$(MAKE) archive
+    
+compile: ${OBJS}
+    
+archive:
+	ar rv $(LIB) ${OBJS}
 
 clean:
 	-rm -f *.o

--- a/src/basic/osg/Makefile
+++ b/src/basic/osg/Makefile
@@ -4,13 +4,20 @@ include ../../makedefs
 LIB = $(OPENEAAGLES_LIB_DIR)/liboeBasic.a
 
 OBJS =  \
-	$(LIB)(Math.o) \
-	$(LIB)(Matrixd.o) \
-	$(LIB)(MatrixDecomposition.o) \
-	$(LIB)(Matrixf.o) \
-	$(LIB)(Quat.o)
+	Math.o \
+	Matrixd.o \
+	MatrixDecomposition.o \
+	Matrixf.o \
+	Quat.o
 
-all: ${OBJS}
+all:
+	$(MAKE) compile
+	$(MAKE) archive
+    
+compile: ${OBJS}
+    
+archive:
+	ar rv $(LIB) ${OBJS}
 
 clean:
 	-rm -f *.o

--- a/src/basic/ubf/Makefile
+++ b/src/basic/ubf/Makefile
@@ -4,13 +4,20 @@ include ../../makedefs
 LIB = $(OPENEAAGLES_LIB_DIR)/liboeBasic.a
 
 OBJS =  \
-	$(LIB)(Action.o) \
-	$(LIB)(Agent.o) \
-	$(LIB)(Arbiter.o) \
-	$(LIB)(Behavior.o) \
-	$(LIB)(State.o)
+	Action.o \
+	Agent.o \
+	Arbiter.o \
+	Behavior.o \
+	State.o
 
-all: ${OBJS}
+all:
+	$(MAKE) compile
+	$(MAKE) archive
+    
+compile: ${OBJS}
+    
+archive:
+	ar rv $(LIB) ${OBJS}
 
 clean:
 	-rm -f *.o

--- a/src/basic/units/Makefile
+++ b/src/basic/units/Makefile
@@ -4,22 +4,29 @@ include ../../makedefs
 LIB = $(OPENEAAGLES_LIB_DIR)/liboeBasic.a
 
 OBJS =  \
-	$(LIB)(Angles.o) \
-	$(LIB)(AngularVelocity.o) \
-	$(LIB)(Areas.o) \
-	$(LIB)(Density.o) \
-	$(LIB)(Distances.o) \
-	$(LIB)(Energies.o) \
-	$(LIB)(FlowRate.o) \
-	$(LIB)(Forces.o) \
-	$(LIB)(Frequencies.o) \
-	$(LIB)(LinearVelocity.o) \
-	$(LIB)(Masses.o) \
-	$(LIB)(Powers.o) \
-	$(LIB)(Times.o) \
-	$(LIB)(Volumes.o)
+	Angles.o \
+	AngularVelocity.o \
+	Areas.o \
+	Density.o \
+	Distances.o \
+	Energies.o \
+	FlowRate.o \
+	Forces.o \
+	Frequencies.o \
+	LinearVelocity.o \
+	Masses.o \
+	Powers.o \
+	Times.o \
+	Volumes.o
 
-all: ${OBJS}
+all:
+	$(MAKE) compile
+	$(MAKE) archive
+    
+compile: ${OBJS}
+    
+archive:
+	ar rv $(LIB) ${OBJS}
 
 clean:
 	-rm -f *.o

--- a/src/basic/util/Makefile
+++ b/src/basic/util/Makefile
@@ -4,9 +4,16 @@ include ../../makedefs
 LIB = $(OPENEAAGLES_LIB_DIR)/liboeBasic.a
 
 OBJS =  \
-	$(LIB)(lfi.o)
+	lfi.o
 
-all: ${OBJS}
+all:
+	$(MAKE) compile
+	$(MAKE) archive
+    
+compile: ${OBJS}
+    
+archive:
+	ar rv $(LIB) ${OBJS}
 
 clean:
 	-rm -f *.o

--- a/src/basicGL/Makefile
+++ b/src/basicGL/Makefile
@@ -4,41 +4,44 @@ include ../makedefs
 LIB = $(OPENEAAGLES_LIB_DIR)/liboeBasicGL.a
 
 OBJS =  \
-	$(LIB)(basicGLFF.o) \
-	$(LIB)(BmpTexture.o) \
-	$(LIB)(BitmapFont.o) \
-	$(LIB)(Clip3D.o) \
-	$(LIB)(ColorGradient.o) \
-	$(LIB)(ColorRotary.o) \
-	$(LIB)(Display.o) \
-	$(LIB)(Factory.o) \
-	$(LIB)(Field.o) \
-	$(LIB)(Font.o) \
-	$(LIB)(FtglFonts.o) \
-	$(LIB)(Graphic.o) \
-	$(LIB)(Image.o) \
-	$(LIB)(Material.o) \
-	$(LIB)(Page.o) \
-	$(LIB)(Polygon.o) \
-	$(LIB)(Readouts.o) \
-	$(LIB)(Reformat.o) \
-	$(LIB)(Rotators.o) \
-	$(LIB)(Scanline.o) \
-	$(LIB)(Shapes.o) \
-	$(LIB)(StrokeFont.o) \
-	$(LIB)(Texture.o) \
-	$(LIB)(MfdPage.o) \
-	$(LIB)(MapPage.o) \
-	$(LIB)(SymbolLoader.o) \
-	$(LIB)(Translator.o)
+	basicGLFF.o \
+	BmpTexture.o \
+	BitmapFont.o \
+	Clip3D.o \
+	ColorGradient.o \
+	ColorRotary.o \
+	Display.o \
+	Factory.o \
+	Field.o \
+	Font.o \
+	FtglFonts.o \
+	Graphic.o \
+	Image.o \
+	Material.o \
+	Page.o \
+	Polygon.o \
+	Readouts.o \
+	Reformat.o \
+	Rotators.o \
+	Scanline.o \
+	Shapes.o \
+	StrokeFont.o \
+	Texture.o \
+	MfdPage.o \
+	MapPage.o \
+	SymbolLoader.o \
+	Translator.o
 
 CPPFLAGS += -I$(FREETYPE2_INC_DIR)
 
-all: ${OBJS}
-
-#Reformat.cpp: Reformat.l
-#	dos2unix Reformat.l
-#	flex -f -oReformat.cpp Reformat.l
+all:
+	$(MAKE) compile
+	$(MAKE) archive
+    
+compile: ${OBJS}
+    
+archive:
+	ar rv $(LIB) ${OBJS}
 
 clean:
 	-rm -f *.o

--- a/src/dafif/Makefile
+++ b/src/dafif/Makefile
@@ -4,20 +4,27 @@ include ../makedefs
 LIB = $(OPENEAAGLES_LIB_DIR)/liboeDafif.a
 
 OBJS =  \
-	$(LIB)(dafifFF.o) \
-	$(LIB)(Airport.o) \
-	$(LIB)(AirportLoader.o) \
-	$(LIB)(Record.o) \
-	$(LIB)(Database.o) \
-	$(LIB)(Factory.o) \
-	$(LIB)(Ils.o) \
-	$(LIB)(Navaid.o) \
-	$(LIB)(NavaidLoader.o) \
-	$(LIB)(Runway.o) \
-	$(LIB)(Waypoint.o) \
-	$(LIB)(WaypointLoader.o)
+	dafifFF.o \
+	Airport.o \
+	AirportLoader.o \
+	Record.o \
+	Database.o \
+	Factory.o \
+	Ils.o \
+	Navaid.o \
+	NavaidLoader.o \
+	Runway.o \
+	Waypoint.o \
+	WaypointLoader.o
 
-all: ${OBJS}
+all:
+	$(MAKE) compile
+	$(MAKE) archive
+    
+compile: ${OBJS}
+    
+archive:
+	ar rv $(LIB) ${OBJS}
 
 clean:
 	-rm -f *.o

--- a/src/dis/Makefile
+++ b/src/dis/Makefile
@@ -4,22 +4,28 @@ include ../makedefs
 LIB = $(OPENEAAGLES_LIB_DIR)/liboeDis.a
 
 OBJS =  \
-	$(LIB)(disFF.o) \
-	$(LIB)(EmissionPduHandler.o) \
-	$(LIB)(Factory.o) \
-	$(LIB)(NetIO.o) \
-	$(LIB)(NetIO-entity-state.o) \
-	$(LIB)(NetIO-munition-detonation.o) \
-	$(LIB)(NetIO-weapon-fire.o) \
-	$(LIB)(Nib.o) \
-	$(LIB)(Nib-entity-state.o) \
-	$(LIB)(Nib-iff.o) \
-	$(LIB)(Nib-munition-detonation.o) \
-	$(LIB)(Nib-weapon-fire.o) \
-	$(LIB)(Ntm.o)
+	disFF.o \
+	EmissionPduHandler.o \
+	Factory.o \
+	NetIO.o \
+	NetIO-entity-state.o \
+	NetIO-munition-detonation.o \
+	NetIO-weapon-fire.o \
+	Nib.o \
+	Nib-entity-state.o \
+	Nib-iff.o \
+	Nib-munition-detonation.o \
+	Nib-weapon-fire.o \
+	Ntm.o
 
-
-all: ${OBJS}
+all:
+	$(MAKE) compile
+	$(MAKE) archive
+    
+compile: ${OBJS}
+    
+archive:
+	ar rv $(LIB) ${OBJS}
 
 clean:
 	-rm -f *.o

--- a/src/dynamics/Makefile
+++ b/src/dynamics/Makefile
@@ -5,16 +5,21 @@ LIB = $(OPENEAAGLES_LIB_DIR)/liboeDynamics.a
 
 CPPFLAGS += -I$(JSBSIM_INC_DIR)
 
-SUBDIRS = 
-
 OBJS =  \
-	$(LIB)(Factory.o) \
-	$(LIB)(JSBSimModel.o) \
-	$(LIB)(LaeroModel.o)  \
-	$(LIB)(RacModel.o) \
-	$(LIB)(dynamicsFF.o)
+	Factory.o \
+	JSBSimModel.o \
+	LaeroModel.o  \
+	RacModel.o \
+	dynamicsFF.o
 
-all: ${OBJS}
+all:
+	$(MAKE) compile
+	$(MAKE) archive
+    
+compile: ${OBJS}
+    
+archive:
+	ar rv $(LIB) ${OBJS}
 
 clean:
 	-rm -f *.o

--- a/src/gui/glut/Makefile
+++ b/src/gui/glut/Makefile
@@ -4,13 +4,20 @@ include ../../makedefs
 LIB = $(OPENEAAGLES_LIB_DIR)/liboeGlut.a
 
 OBJS =  \
-	$(LIB)(Factory.o) \
-	$(LIB)(glutFF.o) \
-	$(LIB)(GlutDisplay.o) \
-	$(LIB)(Shapes3D.o)
+	Factory.o \
+	glutFF.o \
+	GlutDisplay.o \
+	Shapes3D.o
 
-all: ${OBJS}
-
+all:
+	$(MAKE) compile
+	$(MAKE) archive
+    
+compile: ${OBJS}
+    
+archive:
+	ar rv $(LIB) ${OBJS}
+    
 clean:
 	-rm -f *.o
 	-rm -f $(LIB)

--- a/src/instruments/Makefile
+++ b/src/instruments/Makefile
@@ -4,21 +4,28 @@ include ../makedefs
 LIB = $(OPENEAAGLES_LIB_DIR)/liboeInstruments.a
 
 OBJS =  \
-	$(LIB)(Factory.o) \
-	$(LIB)(instrumentsFF.o) \
-	$(LIB)(Instrument.o) 
+	Factory.o \
+	instrumentsFF.o \
+	Instrument.o 
 
 SUBDIRS = adi buttons dials landingGear maps eng gauges eadi3D 
 
-all: subdirs ${OBJS}
-
-subdirs:
+all:
+	$(MAKE) compile
+	$(MAKE) archive
+    
+compile: $(SUBDIRS) ${OBJS}
+    
+archive:
 	for subdir in $(SUBDIRS); do \
-	  echo making $@ in $$subdir; \
-	  (cd $$subdir && $(MAKE)) || exit 1; \
+		$(MAKE) -C $$subdir $(MAKECMDGOALS); \
 	done
+	ar rv $(LIB) ${OBJS}
 
-clean:
+clean: $(SUBDIRS)
 	-rm -f *.o
 	-rm -f $(LIB)
+    
+$(SUBDIRS)::
+	$(MAKE) -C $@ $(MAKECMDGOALS)
 

--- a/src/instruments/adi/Makefile
+++ b/src/instruments/adi/Makefile
@@ -4,10 +4,17 @@ include ../../makedefs
 LIB = $(OPENEAAGLES_LIB_DIR)/liboeInstruments.a
 
 OBJS =  \
-	$(LIB)(Adi.o) \
-	$(LIB)(GhostHorizon.o)
+	Adi.o \
+	GhostHorizon.o
 
-all: ${OBJS}
+all:
+	$(MAKE) compile
+	$(MAKE) archive
+    
+compile: ${OBJS}
+    
+archive:
+	ar rv $(LIB) ${OBJS}
 
 clean:
 	-rm -f *.o

--- a/src/instruments/buttons/Makefile
+++ b/src/instruments/buttons/Makefile
@@ -4,14 +4,21 @@ include ../../makedefs
 LIB = $(OPENEAAGLES_LIB_DIR)/liboeInstruments.a
 
 OBJS =  \
-	$(LIB)(Button.o) \
-	$(LIB)(PushButton.o) \
-	$(LIB)(RotarySwitch.o) \
-	$(LIB)(Knob.o) \
-	$(LIB)(Switch.o) \
-	$(LIB)(SolenoidSwitch.o) 
+	Button.o \
+	PushButton.o \
+	RotarySwitch.o \
+	Knob.o \
+	Switch.o \
+	SolenoidSwitch.o 
 
-all: ${OBJS}
+all:
+	$(MAKE) compile
+	$(MAKE) archive
+    
+compile: ${OBJS}
+    
+archive:
+	ar rv $(LIB) ${OBJS}
 
 clean:
 	-rm -f *.o

--- a/src/instruments/dials/Makefile
+++ b/src/instruments/dials/Makefile
@@ -4,14 +4,21 @@ include ../../makedefs
 LIB = $(OPENEAAGLES_LIB_DIR)/liboeInstruments.a
 
 OBJS =  \
-	$(LIB)(AltitudeDial.o) \
-	$(LIB)(AnalogDial.o) \
-	$(LIB)(DialArcSegment.o) \
-	$(LIB)(DialPointer.o) \
-	$(LIB)(DialTickMarks.o) \
-	$(LIB)(GMeterDial.o)
+	AltitudeDial.o \
+	AnalogDial.o \
+	DialArcSegment.o \
+	DialPointer.o \
+	DialTickMarks.o \
+	GMeterDial.o
 
-all: ${OBJS}
+all:
+	$(MAKE) compile
+	$(MAKE) archive
+    
+compile: ${OBJS}
+    
+archive:
+	ar rv $(LIB) ${OBJS}
 
 clean:
 	-rm -f *.o

--- a/src/instruments/eadi3D/Makefile
+++ b/src/instruments/eadi3D/Makefile
@@ -4,11 +4,18 @@ include ../../makedefs
 LIB = $(OPENEAAGLES_LIB_DIR)/liboeInstruments.a
 
 OBJS =  \
-	$(LIB)(Eadi3DObjects.o) \
-	$(LIB)(Eadi3DPage.o) \
-	$(LIB)(IrisGLCompat.o)
+	Eadi3DObjects.o \
+	Eadi3DPage.o \
+	IrisGLCompat.o
 
-all: ${OBJS}
+all:
+	$(MAKE) compile
+	$(MAKE) archive
+    
+compile: ${OBJS}
+    
+archive:
+	ar rv $(LIB) ${OBJS}
 
 clean:
 	-rm -f *.o

--- a/src/instruments/eng/Makefile
+++ b/src/instruments/eng/Makefile
@@ -4,9 +4,16 @@ include ../../makedefs
 LIB = $(OPENEAAGLES_LIB_DIR)/liboeInstruments.a
 
 OBJS =  \
-	$(LIB)(EngPage.o)
+	EngPage.o
 
-all: ${OBJS}
+all:
+	$(MAKE) compile
+	$(MAKE) archive
+    
+compile: ${OBJS}
+    
+archive:
+	ar rv $(LIB) ${OBJS}
 
 clean:
 	-rm -f *.o

--- a/src/instruments/gauges/Makefile
+++ b/src/instruments/gauges/Makefile
@@ -4,13 +4,20 @@ include ../../makedefs
 LIB = $(OPENEAAGLES_LIB_DIR)/liboeInstruments.a
 
 OBJS =  \
-	$(LIB)(AnalogGauge.o) \
-	$(LIB)(AoaIndexer.o) \
-	$(LIB)(GaugeSlider.o) \
-	$(LIB)(Tape.o) \
-	$(LIB)(TickMarks.o)
+	AnalogGauge.o \
+	AoaIndexer.o \
+	GaugeSlider.o \
+	Tape.o \
+	TickMarks.o
 
-all: ${OBJS}
+all:
+	$(MAKE) compile
+	$(MAKE) archive
+    
+compile: ${OBJS}
+    
+archive:
+	ar rv $(LIB) ${OBJS}
 
 clean:
 	-rm -f *.o

--- a/src/instruments/landingGear/Makefile
+++ b/src/instruments/landingGear/Makefile
@@ -4,10 +4,17 @@ include ../../makedefs
 LIB = $(OPENEAAGLES_LIB_DIR)/liboeInstruments.a
 
 OBJS =  \
-	$(LIB)(LandingGear.o) \
-	$(LIB)(LandingLight.o)
+	LandingGear.o \
+	LandingLight.o
 
-all: ${OBJS}
+all:
+	$(MAKE) compile
+	$(MAKE) archive
+    
+compile: ${OBJS}
+    
+archive:
+	ar rv $(LIB) ${OBJS}
 
 clean:
 	-rm -f *.o

--- a/src/instruments/maps/Makefile
+++ b/src/instruments/maps/Makefile
@@ -4,10 +4,17 @@ include ../../makedefs
 LIB = $(OPENEAAGLES_LIB_DIR)/liboeInstruments.a
 
 OBJS =  \
-	$(LIB)(BearingPointer.o) \
-	$(LIB)(CompassRose.o) 
+	BearingPointer.o \
+	CompassRose.o 
 
-all: ${OBJS}
+all:
+	$(MAKE) compile
+	$(MAKE) archive
+    
+compile: ${OBJS}
+    
+archive:
+	ar rv $(LIB) ${OBJS}
 
 clean:
 	-rm -f *.o

--- a/src/ioDevice/Makefile
+++ b/src/ioDevice/Makefile
@@ -17,7 +17,7 @@ OBJS =  \
 
 # specific IO devices to be included in compile
 ifdef JOYSTICKDEVICE
-OBJS += windows/UsbJoystickImp.o
+OBJS += linux/UsbJoystickImp.o
 endif
 
 all:

--- a/src/ioDevice/Makefile
+++ b/src/ioDevice/Makefile
@@ -4,23 +4,30 @@ include ../makedefs
 LIB = $(OPENEAAGLES_LIB_DIR)/liboeIoDevice.a
 
 OBJS =  \
-	$(LIB)(Ai2DiSwitch.o) \
-	$(LIB)(AnalogInput.o) \
-	$(LIB)(AnalogOutput.o) \
-	$(LIB)(DiscreteInput.o) \
-	$(LIB)(DiscreteOutput.o) \
-	$(LIB)(Factory.o) \
-	$(LIB)(IoData.o) \
-	$(LIB)(ioDeviceFF.o) \
-	$(LIB)(SignalGen.o) \
-	$(LIB)(UsbJoystick.o)
+	Ai2DiSwitch.o \
+	AnalogInput.o \
+	AnalogOutput.o \
+	DiscreteInput.o \
+	DiscreteOutput.o \
+	Factory.o \
+	IoData.o \
+	ioDeviceFF.o \
+	SignalGen.o \
+	UsbJoystick.o
 
 # specific IO devices to be included in compile
 ifdef JOYSTICKDEVICE
-OBJS += $(LIB)(linux/UsbJoystickImp.o)
+OBJS += windows/UsbJoystickImp.o
 endif
 
-all: ${OBJS}
+all:
+	$(MAKE) compile
+	$(MAKE) archive
+    
+compile: ${OBJS}
+    
+archive:
+	ar rv $(LIB) ${OBJS}
 
 clean:
 	-rm -f *.o

--- a/src/linearSys/Makefile
+++ b/src/linearSys/Makefile
@@ -4,22 +4,28 @@ include ../makedefs
 LIB = $(OPENEAAGLES_LIB_DIR)/liboeLinearSys.a
 
 OBJS =  \
-	$(LIB)(DiffEquation.o) \
-	$(LIB)(FirstOrderTf.o) \
-	$(LIB)(LagFilter.o) \
-	$(LIB)(Limit01.o) \
-	$(LIB)(Limit11.o) \
-	$(LIB)(Limit.o) \
-	$(LIB)(LimitFunc.o) \
-	$(LIB)(LowpassFilter.o) \
-	$(LIB)(SaH.o) \
-	$(LIB)(ScalerFunc.o) \
-	$(LIB)(SecondOrderTf.o) \
-	$(LIB)(Sz1.o) \
-	$(LIB)(Sz2.o)
+	DiffEquation.o \
+	FirstOrderTf.o \
+	LagFilter.o \
+	Limit01.o \
+	Limit11.o \
+	Limit.o \
+	LimitFunc.o \
+	LowpassFilter.o \
+	SaH.o \
+	ScalerFunc.o \
+	SecondOrderTf.o \
+	Sz1.o \
+	Sz2.o
 
-
-all: ${OBJS}
+all:
+	$(MAKE) compile
+	$(MAKE) archive
+    
+compile: ${OBJS}
+    
+archive:
+	ar rv $(LIB) ${OBJS}
 
 clean:
 	-rm -f *.o

--- a/src/maps/Makefile
+++ b/src/maps/Makefile
@@ -4,20 +4,27 @@ include ../makedefs
 LIB = $(OPENEAAGLES_LIB_DIR)/liboeMaps.a
 
 OBJS =  \
-	$(LIB)(Factory.o) \
-	$(LIB)(mapsFF.o)
+	Factory.o \
+	mapsFF.o
 
 SUBDIRS = rpfMap
 
-all: subdirs ${OBJS}
-
-subdirs:
+all:
+	$(MAKE) compile
+	$(MAKE) archive
+    
+compile: $(SUBDIRS) ${OBJS}
+    
+archive:
 	for subdir in $(SUBDIRS); do \
-	  echo making $@ in $$subdir; \
-	  (cd $$subdir && $(MAKE)) || exit 1; \
+		$(MAKE) -C $$subdir $(MAKECMDGOALS); \
 	done
+	ar rv $(LIB) ${OBJS}
 
-clean:
+clean: $(SUBDIRS)
 	-rm -f *.o
 	-rm -f $(LIB)
+    
+$(SUBDIRS)::
+	$(MAKE) -C $@ $(MAKECMDGOALS)
 

--- a/src/maps/rpfMap/Makefile
+++ b/src/maps/rpfMap/Makefile
@@ -4,18 +4,25 @@ include ../../makedefs
 LIB = $(OPENEAAGLES_LIB_DIR)/liboeMaps.a
 
 OBJS = \
-	$(LIB)(CadrgClut.o) \
-	$(LIB)(CadrgFile.o) \
-	$(LIB)(CadrgFrame.o) \
-	$(LIB)(CadrgFrameEntry.o) \
-	$(LIB)(CadrgMap.o) \
-	$(LIB)(CadrgTocEntry.o) \
-	$(LIB)(MapDrawer.o) \
-	$(LIB)(TexturePager.o) \
-	$(LIB)(TextureTable.o) \
-	$(LIB)(Support.o) 
+	CadrgClut.o \
+	CadrgFile.o \
+	CadrgFrame.o \
+	CadrgFrameEntry.o \
+	CadrgMap.o \
+	CadrgTocEntry.o \
+	MapDrawer.o \
+	TexturePager.o \
+	TextureTable.o \
+	Support.o 
 
-all: ${OBJS}
+all:
+	$(MAKE) compile
+	$(MAKE) archive
+    
+compile: ${OBJS}
+    
+archive:
+	ar rv $(LIB) ${OBJS}
 
 clean:
 	-rm -f *.o

--- a/src/otw/Makefile
+++ b/src/otw/Makefile
@@ -1,18 +1,22 @@
 #
 include ../makedefs
 
-#CPPFLAGS += -DCIGI_LITTLE_ENDIAN
-#CPPFLAGS += -I$(CIGICL_DIR)
-
 LIB = $(OPENEAAGLES_LIB_DIR)/liboeOtw.a
 
 OBJS =  \
-	$(LIB)(Factory.o) \
-	$(LIB)(OtwCigiCl.o) \
-	$(LIB)(OtwPC.o) \
-	$(LIB)(otwFF.o)
+	Factory.o \
+	OtwCigiCl.o \
+	OtwPC.o \
+	otwFF.o
 
-all: ${OBJS}
+all:
+	$(MAKE) compile
+	$(MAKE) archive
+    
+compile: ${OBJS}
+    
+archive:
+	ar rv $(LIB) ${OBJS}
 
 clean:
 	-rm -f *.o

--- a/src/recorder/Makefile
+++ b/src/recorder/Makefile
@@ -4,32 +4,39 @@ include ../makedefs
 LIB = $(OPENEAAGLES_LIB_DIR)/liboeRecorder.a
 
 OBJS =  \
-	$(LIB)(DataRecorder.o) \
-	$(LIB)(DataRecordHandle.o) \
-	$(LIB)(Factory.o) \
-	$(LIB)(FileReader.o) \
-	$(LIB)(FileWriter.o) \
-	$(LIB)(InputHandler.o) \
-	$(LIB)(NetInput.o) \
-	$(LIB)(NetOutput.o) \
-	$(LIB)(OutputHandler.o) \
-	$(LIB)(PrintHandler.o) \
-	$(LIB)(PrintPlayer.o) \
-	$(LIB)(PrintSelected.o) \
-	$(LIB)(recorderFF.o) \
-	$(LIB)(TabPrinter.o)
+	DataRecorder.o \
+	DataRecordHandle.o \
+	Factory.o \
+	FileReader.o \
+	FileWriter.o \
+	InputHandler.o \
+	NetInput.o \
+	NetOutput.o \
+	OutputHandler.o \
+	PrintHandler.o \
+	PrintPlayer.o \
+	PrintSelected.o \
+	recorderFF.o \
+	TabPrinter.o
 
 SUBDIRS = protobuf
 
-all: subdirs ${OBJS}
-
-subdirs:
+all:
+	$(MAKE) compile
+	$(MAKE) archive
+    
+compile: $(SUBDIRS) ${OBJS}
+    
+archive:
 	for subdir in $(SUBDIRS); do \
-	  echo making $@ in $$subdir; \
-	  (cd $$subdir && $(MAKE)) || exit 1; \
+		$(MAKE) -C $$subdir $(MAKECMDGOALS); \
 	done
+	ar rv $(LIB) ${OBJS}
 
-clean:
+clean: $(SUBDIRS)
 	-rm -f *.o
 	-rm -f $(LIB)
+    
+$(SUBDIRS)::
+	$(MAKE) -C $@ $(MAKECMDGOALS)
 

--- a/src/recorder/protobuf/Makefile
+++ b/src/recorder/protobuf/Makefile
@@ -3,10 +3,19 @@ include ../../makedefs
 
 LIB = $(OPENEAAGLES_LIB_DIR)/liboeRecorder.a
 
-OBJS =  \
-	$(LIB)(DataRecord.pb.o)
+CPPFLAGS += -I$(OE_ROOT)/include/openeaagles/recorder/protobuf
 
-all: ${OBJS}
+OBJS =  \
+	DataRecord.pb.o
+
+all:
+	$(MAKE) compile
+	$(MAKE) archive
+    
+compile: ${OBJS}
+    
+archive:
+	ar rv $(LIB) ${OBJS}
 
 clean:
 	-rm -f *.o

--- a/src/sensors/Makefile
+++ b/src/sensors/Makefile
@@ -4,13 +4,20 @@ include ../makedefs
 LIB = $(OPENEAAGLES_LIB_DIR)/liboeSensors.a
 
 OBJS =  \
-	$(LIB)(Factory.o) \
-	$(LIB)(Gmti.o) \
-	$(LIB)(sensorsFF.o) \
-	$(LIB)(Stt.o) \
-	$(LIB)(Tws.o)
+	Factory.o \
+	Gmti.o \
+	sensorsFF.o \
+	Stt.o \
+	Tws.o
 
-all: ${OBJS} 
+all:
+	$(MAKE) compile
+	$(MAKE) archive
+    
+compile: ${OBJS}
+    
+archive:
+	ar rv $(LIB) ${OBJS}
 
 clean:
 	-rm -f *.o

--- a/src/simulation/Makefile
+++ b/src/simulation/Makefile
@@ -4,106 +4,107 @@ include ../makedefs
 LIB = $(OPENEAAGLES_LIB_DIR)/liboeSimulation.a
 
 OBJS =  \
-	$(LIB)(Aam.o) \
-	$(LIB)(Actions.o) \
-	$(LIB)(Agm.o) \
-	$(LIB)(AircraftIrSignature.o) \
-	$(LIB)(AirVehicle.o) \
-	$(LIB)(AngleOnlyTrackManager.o) \
-	$(LIB)(Antenna.o) \
-	$(LIB)(Autopilot.o) \
-	$(LIB)(AvionicsPod.o) \
-	$(LIB)(Bomb.o) \
-	$(LIB)(Buildings.o) \
-	$(LIB)(Bullseye.o) \
-	$(LIB)(CollisionDetect.o) \
-	$(LIB)(Datalink.o) \
-	$(LIB)(DataRecorder.o) \
-	$(LIB)(Designator.o) \
-	$(LIB)(DynamicsModel.o) \
-	$(LIB)(Effects.o) \
-	$(LIB)(Emission.o) \
-	$(LIB)(ExternalStore.o) \
-	$(LIB)(Factory.o) \
-	$(LIB)(FuelTank.o) \
-	$(LIB)(Gimbal.o) \
-	$(LIB)(Gps.o) \
-	$(LIB)(GroundVehicle.o) \
-	$(LIB)(Guns.o) \
-	$(LIB)(Iff.o) \
-	$(LIB)(Image.o) \
-	$(LIB)(Ins.o) \
-	$(LIB)(IrAtmosphere.o) \
-	$(LIB)(IrAtmosphere1.o) \
-	$(LIB)(IrQueryMsg.o) \
-	$(LIB)(IrSeeker.o) \
-	$(LIB)(IrSensor.o) \
-	$(LIB)(IrShapes.o) \
-	$(LIB)(IrSignature.o) \
-	$(LIB)(IrSystem.o) \
-	$(LIB)(Jammer.o) \
-	$(LIB)(LifeForms.o) \
-	$(LIB)(MergingIrSensor.o) \
-	$(LIB)(Message.o) \
-	$(LIB)(Missile.o) \
-	$(LIB)(MultiActorAgent.o) \
-	$(LIB)(Navigation.o) \
-	$(LIB)(NavRadios.o) \
-	$(LIB)(NetIO.o) \
-	$(LIB)(Nib.o) \
-	$(LIB)(Ntm.o) \
-	$(LIB)(OnboardComputer.o) \
-	$(LIB)(Otw.o) \
-	$(LIB)(Pilot.o) \
-	$(LIB)(Player.o) \
-	$(LIB)(Radar.o) \
-	$(LIB)(Radio.o) \
-	$(LIB)(RfSensor.o) \
-	$(LIB)(RfSystem.o) \
-	$(LIB)(Route.o) \
-	$(LIB)(Rwr.o) \
-	$(LIB)(Sam.o) \
-	$(LIB)(SamVehicles.o) \
-	$(LIB)(Sar.o) \
-	$(LIB)(ScanGimbal.o) \
-	$(LIB)(SensorMsg.o) \
-	$(LIB)(Ships.o) \
-	$(LIB)(Signatures.o) \
-	$(LIB)(SimAgent.o) \
-	$(LIB)(SimLogger.o) \
-	$(LIB)(Simulation.o) \
-	$(LIB)(simulationFF.o) \
-	$(LIB)(SpaceVehicle.o) \
-	$(LIB)(StabilizingGimbal.o) \
-	$(LIB)(Station.o) \
-	$(LIB)(Steerpoint.o) \
-	$(LIB)(Stores.o) \
-	$(LIB)(StoresMgr.o) \
-	$(LIB)(SynchronizedState.o) \
-	$(LIB)(System.o) \
-	$(LIB)(TabLogger.o) \
-	$(LIB)(TargetData.o) \
-	$(LIB)(Tdb.o) \
-	$(LIB)(Track.o) \
-	$(LIB)(TrackManager.o) \
-	$(LIB)(Weapon.o)
+	Aam.o \
+	Actions.o \
+	Agm.o \
+	AircraftIrSignature.o \
+	AirVehicle.o \
+	AngleOnlyTrackManager.o \
+	Antenna.o \
+	Autopilot.o \
+	AvionicsPod.o \
+	Bomb.o \
+	Buildings.o \
+	Bullseye.o \
+	CollisionDetect.o \
+	Datalink.o \
+	DataRecorder.o \
+	Designator.o \
+	DynamicsModel.o \
+	Effects.o \
+	Emission.o \
+	ExternalStore.o \
+	Factory.o \
+	FuelTank.o \
+	Gimbal.o \
+	Gps.o \
+	GroundVehicle.o \
+	Guns.o \
+	Iff.o \
+	Image.o \
+	Ins.o \
+	IrAtmosphere.o \
+	IrAtmosphere1.o \
+	IrQueryMsg.o \
+	IrSeeker.o \
+	IrSensor.o \
+	IrShapes.o \
+	IrSignature.o \
+	IrSystem.o \
+	Jammer.o \
+	LifeForms.o \
+	MergingIrSensor.o \
+	Message.o \
+	Missile.o \
+	MultiActorAgent.o \
+	Navigation.o \
+	NavRadios.o \
+	NetIO.o \
+	Nib.o \
+	Ntm.o \
+	OnboardComputer.o \
+	Otw.o \
+	Pilot.o \
+	Player.o \
+	Radar.o \
+	Radio.o \
+	RfSensor.o \
+	RfSystem.o \
+	Route.o \
+	Rwr.o \
+	Sam.o \
+	SamVehicles.o \
+	Sar.o \
+	ScanGimbal.o \
+	SensorMsg.o \
+	Ships.o \
+	Signatures.o \
+	SimAgent.o \
+	SimLogger.o \
+	Simulation.o \
+	simulationFF.o \
+	SpaceVehicle.o \
+	StabilizingGimbal.o \
+	Station.o \
+	Steerpoint.o \
+	Stores.o \
+	StoresMgr.o \
+	SynchronizedState.o \
+	System.o \
+	TabLogger.o \
+	TargetData.o \
+	Tdb.o \
+	Track.o \
+	TrackManager.o \
+	Weapon.o
 
 SUBDIRS = dynamics
 
-all: ${OBJS}
-
-all: subdirs ${OBJS}
-
-subdirs:
+all:
+	$(MAKE) compile
+	$(MAKE) archive
+    
+compile: $(SUBDIRS) ${OBJS}
+    
+archive:
 	for subdir in $(SUBDIRS); do \
-	  echo making $@ in $$subdir; \
-	  (cd $$subdir && $(MAKE)) || exit 1; \
+		$(MAKE) -C $$subdir $(MAKECMDGOALS); \
 	done
+	ar rv $(LIB) ${OBJS}
 
-clean:
+clean: $(SUBDIRS)
 	-rm -f *.o
-	for subdir in $(SUBDIRS); do \
-	    echo making $@ in $$subdir; \
-	    (cd $$subdir && $(MAKE) $@) || exit 1; \
-	done
 	-rm -f $(LIB)
+    
+$(SUBDIRS)::
+	$(MAKE) -C $@ $(MAKECMDGOALS)

--- a/src/simulation/dynamics/Makefile
+++ b/src/simulation/dynamics/Makefile
@@ -4,10 +4,17 @@ include ../../makedefs
 LIB = $(OPENEAAGLES_LIB_DIR)/liboeSimulation.a
 
 OBJS =  \
-	$(LIB)(AerodynamicsModel.o) \
-	$(LIB)(SpaceDynamicsModel.o)
+	AerodynamicsModel.o \
+	SpaceDynamicsModel.o
 
-all: ${OBJS}
+all:
+	$(MAKE) compile
+	$(MAKE) archive
+    
+compile: ${OBJS}
+    
+archive:
+	ar rv $(LIB) ${OBJS}
 
 clean:
 	-rm -f *.o

--- a/src/terrain/Makefile
+++ b/src/terrain/Makefile
@@ -4,21 +4,28 @@ include ../makedefs
 LIB = $(OPENEAAGLES_LIB_DIR)/liboeTerrain.a
 
 OBJS =  \
-	$(LIB)(DataFile.o) \
-	$(LIB)(Factory.o) \
-	$(LIB)(QuadMap.o) \
-	$(LIB)(terrainFF.o)
+	DataFile.o \
+	Factory.o \
+	QuadMap.o \
+	terrainFF.o
 
 SUBDIRS = ded dted srtm
 
-all: subdirs ${OBJS}
-
-subdirs:
+all:
+	$(MAKE) compile
+	$(MAKE) archive
+    
+compile: $(SUBDIRS) ${OBJS}
+    
+archive:
 	for subdir in $(SUBDIRS); do \
-	  echo making $@ in $$subdir; \
-	  (cd $$subdir && $(MAKE)) || exit 1; \
+		$(MAKE) -C $$subdir $(MAKECMDGOALS); \
 	done
+	ar rv $(LIB) ${OBJS}
 
-clean:
+clean: $(SUBDIRS)
 	-rm -f *.o
 	-rm -f $(LIB)
+    
+$(SUBDIRS)::
+	$(MAKE) -C $@ $(MAKECMDGOALS)

--- a/src/terrain/ded/Makefile
+++ b/src/terrain/ded/Makefile
@@ -3,9 +3,16 @@ include ../../makedefs
 
 LIB = $(OPENEAAGLES_LIB_DIR)/liboeTerrain.a
 
-OBJS =  $(LIB)(DedFile.o) 
+OBJS =  DedFile.o 
 
-all: ${OBJS} 
+all:
+	$(MAKE) compile
+	$(MAKE) archive
+    
+compile: ${OBJS}
+    
+archive:
+	ar rv $(LIB) ${OBJS}
 
 clean:
 	-rm -f *.o

--- a/src/terrain/dted/Makefile
+++ b/src/terrain/dted/Makefile
@@ -3,9 +3,16 @@ include ../../makedefs
 
 LIB = $(OPENEAAGLES_LIB_DIR)/liboeTerrain.a
 
-OBJS =  $(LIB)(DtedFile.o) 
+OBJS =  DtedFile.o 
 
-all: ${OBJS} 
+all:
+	$(MAKE) compile
+	$(MAKE) archive
+    
+compile: ${OBJS}
+    
+archive:
+	ar rv $(LIB) ${OBJS}
 
 clean:
 	-rm -f *.o

--- a/src/terrain/srtm/Makefile
+++ b/src/terrain/srtm/Makefile
@@ -3,9 +3,16 @@ include ../../makedefs
 
 LIB = $(OPENEAAGLES_LIB_DIR)/liboeTerrain.a
 
-OBJS =  $(LIB)(SrtmHgtFile.o) 
+OBJS =  SrtmHgtFile.o 
 
-all: ${OBJS} 
+all:
+	$(MAKE) compile
+	$(MAKE) archive
+    
+compile: ${OBJS}
+    
+archive:
+	ar rv $(LIB) ${OBJS}
 
 clean:
 	-rm -f *.o


### PR DESCRIPTION
Before, builds couldn't be done with more than one Make job because of race conditions on the library files (i.e. multiple jobs trying to write to the same .a file at the same time). In order to prevent this, the compilation and the archiving phases of the build process were broken into two separate phases. The first, compilation, can be done as concurrently as desired because there are no dependencies. The second phase, archiving, must be done sequentially though because the files related to each library are nicely separated into subdirectories of src/, the Makefiles for those subdirectories (both phases) can be run concurrently to each other. 

I did some very crude benchmarking of these changes. I used the Linux time(1) utility and averaged the values for three runs.

Current Build Process (`make`):
real    5m20.482s
user    0m6.782s
sys     0m9.327s

New Build Process (`make -j 4`):
real     2m28.016s
user    0m7.1297s
sys      0m11.431s

So in my environment, I am getting more than a 50% speedup from these changes. You'll notice that both the user and sys time went up after the changes though. I would venture to say that this is because of the additional overhead related to my method of splitting up the two build phases. Regardless, the real time improvement is significant. 

Additionally, I compared the libraries generated using the old build process and the new build process using the procedure described in this [Gist](https://gist.github.com/jmc734/20f8467d1cecf1a78d52). In addition to the shell commands, a tar.gz file containing the outputs is attached. As you can see, the generated libraries are identical (disregarding ordering of object files within the libraries). 

